### PR TITLE
Update GNOME runtime to 40 & drop libhandy dep

### DIFF
--- a/org.gnome.gitlab.somas.Apostrophe.json
+++ b/org.gnome.gitlab.somas.Apostrophe.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.gitlab.somas.Apostrophe",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.38",
+  "runtime-version": "40",
   "sdk": "org.gnome.Sdk",
   "command": "apostrophe",
   "finish-args": [
@@ -22,20 +22,6 @@
     }
   },
   "modules": [
-    {
-      "name": "libhandy",
-      "buildsystem": "meson",
-      "config-opts": [
-        "--buildtype=release"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.gnome.org/GNOME/libhandy",
-          "tag": "1.0.3"
-        }
-      ]
-    },
     {
       "name": "gspell",
       "sources": [


### PR DESCRIPTION
libhandy now is a part of new GNOME 40 runtime so we can drop custom build.