### PR TITLE
Install Pandoc on aarch64 platforms

### DIFF
--- a/org.gnome.gitlab.somas.Apostrophe.json
+++ b/org.gnome.gitlab.somas.Apostrophe.json
@@ -35,7 +35,7 @@
     {
       "name": "pandoc",
       "only-arches": [
-        "x86_64"
+        "x86_64", "aarch64"
       ],
       "buildsystem": "simple",
       "build-commands": [
@@ -44,8 +44,15 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/jgm/pandoc/releases/download/2.11.3.1/pandoc-2.13-linux-amd64.tar.gz",
-          "sha256": "7404aa88a6eb9fbb99d9803b80170a3a546f51959230cc529c66a2ce6b950d4c"
+          "url": "https://github.com/jgm/pandoc/releases/download/2.13/pandoc-2.13-linux-amd64.tar.gz",
+          "sha256": "7404aa88a6eb9fbb99d9803b80170a3a546f51959230cc529c66a2ce6b950d4c",
+          "only-arches": ["x86_64"]
+        },
+        {
+          "type": "archive",
+          "url": "https://github.com/jgm/pandoc/releases/download/2.13/pandoc-2.13-linux-arm64.tar.gz",
+          "sha256": "4f87bfe8a0a626ad0e17d26d42e99a1c0ed7d369cca00366c1b3d97525f57db5",
+          "only-arches": ["aarch64"]
         }
       ]
     },

--- a/org.gnome.gitlab.somas.Apostrophe.json
+++ b/org.gnome.gitlab.somas.Apostrophe.json
@@ -44,8 +44,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/jgm/pandoc/releases/download/2.11.3.1/pandoc-2.11.3.1-linux-amd64.tar.gz",
-          "sha256": "848fd7e6ccfe8a8d5a9ff81ea9b6a3024e8d0e8da6365d304584d93b87da8996"
+          "url": "https://github.com/jgm/pandoc/releases/download/2.11.3.1/pandoc-2.13-linux-amd64.tar.gz",
+          "sha256": "7404aa88a6eb9fbb99d9803b80170a3a546f51959230cc529c66a2ce6b950d4c"
         }
       ]
     },

--- a/org.gnome.gitlab.somas.Apostrophe.json
+++ b/org.gnome.gitlab.somas.Apostrophe.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.gitlab.somas.Apostrophe",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.38",
+  "runtime-version": "40",
   "sdk": "org.gnome.Sdk",
   "command": "apostrophe",
   "finish-args": [
@@ -22,20 +22,6 @@
     }
   },
   "modules": [
-    {
-      "name": "libhandy",
-      "buildsystem": "meson",
-      "config-opts": [
-        "--buildtype=release"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.gnome.org/GNOME/libhandy",
-          "tag": "1.0.3"
-        }
-      ]
-    },
     {
       "name": "gspell",
       "sources": [


### PR DESCRIPTION
Pandoc now provides pre-built aarch64 binaries. This PR updates Pandoc to 2.13 (from 2.11.3.1) and adds the aarch64 download.

Depends on #4.