### PR TITLE
Update GNOME runtime to 41

### DIFF
--- a/org.gnome.gitlab.somas.Apostrophe.json
+++ b/org.gnome.gitlab.somas.Apostrophe.json
@@ -5,6 +5,7 @@
   "sdk": "org.gnome.Sdk",
   "command": "apostrophe",
   "finish-args": [
+    "--device=dri",
     "--socket=fallback-x11",
     "--socket=wayland",
     "--share=ipc",

--- a/org.gnome.gitlab.somas.Apostrophe.json
+++ b/org.gnome.gitlab.somas.Apostrophe.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.gitlab.somas.Apostrophe",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "40",
+  "runtime-version": "41",
   "sdk": "org.gnome.Sdk",
   "command": "apostrophe",
   "finish-args": [


### PR DESCRIPTION
Update to latest GNOME runtime 41 and add finish-args: `device=dri` for OpenGL rendering.

`device=dri`: according to talks with other maintainers this will not hurt and should been added to all gtk apps. Only if there some serious reasons to no adding it. Thanks in advance.
