### PR TITLE
Update GNOME runtime to 42 & drop libhandy dep

### DIFF
--- a/org.gnome.gitlab.somas.Apostrophe.json
+++ b/org.gnome.gitlab.somas.Apostrophe.json
@@ -24,22 +24,6 @@
   },
   "modules": [
     {
-      "name": "libhandy",
-      "buildsystem": "meson",
-      "builddir": true,
-      "config-opts": [
-        "-Dexamples=false",
-        "-Dtests=false"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.gnome.org/GNOME/libhandy.git",
-          "branch": "main"
-        }
-      ]
-    },
-    {
       "name": "libsass",
       "cleanup": [
         "*"

--- a/org.gnome.gitlab.somas.Apostrophe.json
+++ b/org.gnome.gitlab.somas.Apostrophe.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.gitlab.somas.Apostrophe",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "41",
+  "runtime-version": "42",
   "sdk": "org.gnome.Sdk",
   "command": "apostrophe",
   "finish-args": [


### PR DESCRIPTION
Latest `libhandy` provided by new GNOME runtime. No reason to bundle it.

Basic test: OK.

---

Updating on recent GNOME runtime 43 not possible now until Apostrophe will be ported on new WebKit2:

```py
Traceback (most recent call last):
  File "/app/bin/apostrophe", line 69, in <module>
    sys.exit(main())
  File "/app/bin/apostrophe", line 63, in main
    return run_application()
  File "/app/bin/apostrophe", line 52, in run_application
    from apostrophe.application import Application
  File "/app/lib/python3.10/site-packages/apostrophe/application.py", line 22, in <module>
    from apostrophe.main_window import MainWindow
  File "/app/lib/python3.10/site-packages/apostrophe/main_window.py", line 28, in <module>
    from apostrophe.preview_handler import PreviewHandler
  File "/app/lib/python3.10/site-packages/apostrophe/preview_handler.py", line 25, in <module>
    gi.require_version('WebKit2', '4.0')
  File "/usr/lib/python3.10/site-packages/gi/__init__.py", line 129, in require_version
    raise ValueError('Namespace %s not available for version %s' %
ValueError: Namespace WebKit2 not available for version 4.0
```