### PR TITLE
Update modules, and add x-checker-data to all

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "automerge-flathubbot-prs": true,
+    "require-important-updates": true
+}

--- a/org.gnome.gitlab.somas.Apostrophe.json
+++ b/org.gnome.gitlab.somas.Apostrophe.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.gitlab.somas.Apostrophe",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "command": "apostrophe",
     "finish-args": [

--- a/org.gnome.gitlab.somas.Apostrophe.json
+++ b/org.gnome.gitlab.somas.Apostrophe.json
@@ -1,177 +1,188 @@
 {
-  "app-id": "org.gnome.gitlab.somas.Apostrophe",
-  "runtime": "org.gnome.Platform",
-  "runtime-version": "44",
-  "sdk": "org.gnome.Sdk",
-  "command": "apostrophe",
-  "finish-args": [
-    "--socket=fallback-x11",
-    "--socket=wayland",
-    "--share=ipc",
-    "--share=network",
-    "--device=dri",
-    "--filesystem=host",
-      "--env=PATH=/app/bin:/usr/bin:/app/extensions/TexLive/2018/bin/x86_64-linux/:/app/extensions/TexLive/2018/bin/aarch64-linux/"
-  ],
-  "cleanup": [
-      "/lib/pkgconfig",
-      "/share/vala",
-      "/share/gir-1.0",
-      "/share/gtk-doc"
-  ],
-  "add-extensions": {
-    "org.gnome.gitlab.somas.Apostrophe.Plugin": {
-      "directory": "extensions",
-      "version": "stable",
-      "subdirectories": true,
-      "no-autodownload": true,
-      "autodelete": true
-    }
-  },
-  "modules": [
-    {
-      "name": "libsass",
-      "cleanup": [
-        "*"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/sass/libsass/archive/3.6.4.tar.gz",
-          "sha256": "f9484d9a6df60576e791566eab2f757a97fd414fce01dd41fc0a693ea5db2889"
-        },
-        {
-          "type": "script",
-          "dest-filename": "autogen.sh",
-          "commands": [
-            "autoreconf -si"
-          ]
+    "app-id": "org.gnome.gitlab.somas.Apostrophe",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "44",
+    "sdk": "org.gnome.Sdk",
+    "command": "apostrophe",
+    "finish-args": [
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--share=ipc",
+        "--share=network",
+        "--device=dri",
+        "--filesystem=host",
+        "--env=PATH=/app/bin:/usr/bin:/app/extensions/TexLive/2018/bin/x86_64-linux/:/app/extensions/TexLive/2018/bin/aarch64-linux/"
+    ],
+    "cleanup": [
+        "/lib/pkgconfig",
+        "/share/vala",
+        "/share/gir-1.0",
+        "/share/gtk-doc"
+    ],
+    "add-extensions": {
+        "org.gnome.gitlab.somas.Apostrophe.Plugin": {
+            "directory": "extensions",
+            "version": "stable",
+            "subdirectories": true,
+            "no-autodownload": true,
+            "autodelete": true
         }
-      ]
     },
-    {
-      "name": "sassc",
-      "cleanup": [
-        "*"
-      ],
-      "sources": [
+    "modules": [
         {
-          "type": "archive",
-          "url": "https://github.com/sass/sassc/archive/3.6.1.tar.gz",
-          "sha256": "8cee391c49a102b4464f86fc40c4ceac3a2ada52a89c4c933d8348e3e4542a60"
+            "name": "libsass",
+            "cleanup": [
+                "*"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "archive-type": "tar-gzip",
+                    "url": "https://api.github.com/repos/sass/libsass/tarball/3.6.5",
+                    "sha512": "5d3bee4b7b8fcd592bcd96fd476d33ad87358a1dc4100914669eb9b84dfbd04eba8fb969a614202b32265310944b9ab20cd33a7076b91f7838c5b17439351e17",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/sass/libsass/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": ".tarball_url"
+                    }
+                },
+                {
+                    "type": "script",
+                    "dest-filename": "autogen.sh",
+                    "commands": [
+                        "autoreconf -si"
+                    ]
+                }
+            ]
         },
         {
-          "type": "script",
-          "dest-filename": "autogen.sh",
-          "commands": [
-            "autoreconf -si"
-          ]
+            "name": "sassc",
+            "cleanup": [
+                "*"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "archive-type": "tar-gzip",
+                    "url": "https://api.github.com/repos/sass/sassc/tarball/3.6.2",
+                    "sha512": "446013d375619ec1fb5d6d23d7db2ea96298530eeaff0171611233f40e84e46ce09ba2dbd09b1f26816cfebd776dd5a515476e1726b2bae19f4b6d21ddbe4f43",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/sass/sassc/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": ".tarball_url"
+                    }
+                },
+                {
+                    "type": "script",
+                    "dest-filename": "autogen.sh",
+                    "commands": [
+                        "autoreconf -si"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "gspell",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gspell/1.12/gspell-1.12.2.tar.xz",
+                    "sha256": "b4e993bd827e4ceb6a770b1b5e8950fce3be9c8b2b0cbeb22fdf992808dd2139",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "gspell"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "pandoc",
+            "buildsystem": "simple",
+            "build-commands": [
+                "cp bin/pandoc /app/bin/pandoc"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "archive-type": "tar-gzip",
+                    "url": "https://github.com/jgm/pandoc/releases/download/3.1.8/pandoc-3.1.8-linux-amd64.tar.gz",
+                    "sha512": "d09fac84c6bba940cc9a57e70c72cce107032d404a33a284687d607baf862bfadae58e8888c326fafb330e1e22a14cdc120d015a17a5dc8dbf795603af0436bf",
+                    "only-arches": [
+                        "x86_64"
+                    ],
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/jgm/pandoc/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": ".assets[] | select(.name==\"pandoc-\" + $version + \"-linux-amd64.tar.gz\") | .browser_download_url"
+                    }
+                },
+                {
+                    "type": "archive",
+                    "archive-type": "tar-gzip",
+                    "url": "https://github.com/jgm/pandoc/releases/download/3.1.8/pandoc-3.1.8-linux-arm64.tar.gz",
+                    "sha512": "4f5d4c643e859d3a77faf48992aa64bef898da76312c4cbbb6cab5f772e5ab8085767938cfa50cb778078dfb4a4cdcf5073fbba6c3941305563b61e920c21a35",
+                    "only-arches": [
+                        "aarch64"
+                    ],
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/jgm/pandoc/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": ".assets[] | select(.name==\"pandoc-\" + $version + \"-linux-arm64.tar.gz\") | .browser_download_url"
+                    }
+                }
+            ]
+        },
+        "python3-modules.json",
+        {
+            "name": "fira",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p /app/share/fonts/",
+                "cp ttf/* /app/share/fonts/"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "archive-type": "tar-gzip",
+                    "url": "https://api.github.com/repos/mozilla/Fira/tarball/4.202",
+                    "sha512": "ab9f00c7290aa252448b0730cecccfea07cd99daec09883d261cc49b88b1dadd13e951511517a359646ebd94e6cd13861f468437d26465a079cf2b86ab999356",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/mozilla/Fira/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": ".tarball_url"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "apostrophe",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://gitlab.gnome.org/World/apostrophe/-/archive/v2.6.3/apostrophe-v2.6.3.tar.bz2",
+                    "sha512": "ca88ba545ea99f1f365091932819fbb9dfc5c30225275090fc5e2b3aa072400aee9918e5f7972ce55860f76d111ed43308ad87f5be02cd289bbf107955f4e172",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://gitlab.gnome.org/api/v4/projects/World%2Fapostrophe/releases/permalink/latest",
+                        "version-query": ".tag_name | sub(\"^v\"; \"\")",
+                        "url-query": ".assets.sources[] | select(.format == \"tar.bz2\" and .url) | .url",
+                        "is-main-source": true
+                    }
+                },
+                {
+                    "type": "patch",
+                    "path": "apostrophe-webkit.patch"
+                }
+            ],
+            "post-install": [
+                "install -d /app/extensions"
+            ]
         }
-      ]
-    },
-    {
-      "name": "gspell",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://download.gnome.org/sources/gspell/1.8/gspell-1.8.3.tar.xz",
-          "sha256": "5ae514dd0216be069176accf6d0049d6a01cfa6a50df4bc06be85f7080b62de8"
-        }
-      ]
-    },
-    {
-      "name": "pandoc",
-      "buildsystem": "simple",
-      "build-commands": [
-        "cp bin/pandoc /app/bin/pandoc"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/jgm/pandoc/releases/download/2.13/pandoc-2.13-linux-amd64.tar.gz",
-          "sha256": "7404aa88a6eb9fbb99d9803b80170a3a546f51959230cc529c66a2ce6b950d4c",
-          "only-arches": ["x86_64"]
-        },
-        {
-          "type": "archive",
-          "url": "https://github.com/jgm/pandoc/releases/download/2.13/pandoc-2.13-linux-arm64.tar.gz",
-          "sha256": "4f87bfe8a0a626ad0e17d26d42e99a1c0ed7d369cca00366c1b3d97525f57db5",
-          "only-arches": ["aarch64"]
-        }
-      ]
-    },
-    {
-      "name": "pipdeps",
-      "buildsystem": "simple",
-      "build-commands": [
-        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} regex pypandoc chardet"
-      ],
-      "sources": [
-        {
-          "type": "file",
-          "url": "https://files.pythonhosted.org/packages/75/28/521c6dc7fef23a68368efefdcd682f5b3d1d58c2b90b06dc1d0b805b51ae/wheel-0.34.2.tar.gz",
-          "sha256": "8788e9155fe14f54164c1b9eb0a319d98ef02c160725587ad60f14ddc57b6f96"
-        },
-        {
-          "type": "file",
-          "url": "https://files.pythonhosted.org/packages/8e/76/66066b7bc71817238924c7e4b448abdb17eb0c92d645769c223f9ace478f/pip-20.0.2.tar.gz",
-          "sha256": "7db0c8ea4c7ea51c8049640e8e6e7fde949de672bfa4949920675563a5a6967f"
-        },
-        {
-          "type": "file",
-          "url": "https://files.pythonhosted.org/packages/71/81/00184643e5a10a456b4118fc12c96780823adb8ed974eb2289f29703b29b/pypandoc-1.4.tar.gz",
-          "sha256": "e914e6d5f84a76764887e4d909b09d63308725f0cbb5293872c2c92f07c11a5b"
-        },
-        {
-          "type": "file",
-          "url": "https://files.pythonhosted.org/packages/e8/76/8ac7f467617b9cfbafcef3c76df6f22b15de654a62bea719792b00a83195/regex-2020.2.20.tar.gz",
-          "sha256": "9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5"
-        },
-        {
-          "type": "file",
-          "url": "https://files.pythonhosted.org/packages/14/4b/6f7a3f2bb1e2fa4d3007126578cae0b9910ff46c4957bef5bd4b92733011/pyenchant-3.0.1.tar.gz",
-          "sha256": "1bd26a644abf80196a9de3f2d820ebafb7e7f78385e392ce77cb1552f164d559"
-        },
-        {
-          "type": "file",
-          "url": "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz",
-          "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"
-        }
-      ]
-    },
-    {
-      "name": "fonts",
-      "buildsystem": "simple",
-      "build-commands": [
-        "mkdir -p /app/share/fonts/",
-        "cp ttf/* /app/share/fonts/"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://github.com/mozilla/Fira",
-          "tag": "4.202"
-        }
-      ]
-    },
-    {
-      "name": "apostrophe",
-      "buildsystem": "meson",
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.gnome.org/World/apostrophe.git",
-          "tag": "v2.6.3",
-          "commit": "0e382ba1636bb9df61775599ad80adedc8596562"
-        },
-        {
-          "type": "patch",
-          "path": "apostrophe-webkit.patch"
-        }
-      ],
-      "post-install": [
-        "install -d /app/extensions"
-      ]
-    }
-  ]
+    ]
 }

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -1,0 +1,82 @@
+{
+    "name": "python3-modules",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-regex",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"regex\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/4f/1d/6998ba539616a4c8f58b07fd7c9b90c6b0f0c0ecbe8db69095a6079537a7/regex-2023.8.8.tar.gz",
+                    "sha256": "fcbdc5f2b0f1cd0f6a56cdb46fe41d2cce1e644e3b68832f3eeebc5fb0f7712e",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "regex"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-pypandoc",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pypandoc\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/59/ac/1380f19d6bab8772b4e40d881091039a8c592d66382bd4c865fa21373bad/pypandoc-1.11-py3-none-any.whl",
+                    "sha256": "b260596934e9cfc6513056110a7c8600171d414f90558bf4407e68b209be8007",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "pypandoc",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-chardet",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"chardet\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl",
+                    "sha256": "e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "chardet",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python3-pyenchant",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyenchant\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/54/4c/a741dddab6ad96f257d90cb4d23067ffadac526c9cab3a99ca6ce3c05477/pyenchant-3.2.2-py3-none-any.whl",
+                    "sha256": "5facc821ece957208a81423af7d6ec7810dad29697cb0d77aae81e4e11c8e5a6",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "pyenchant",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR updates:
 - runtime 44 -> 45
 - libsass 3.6.4 -> 3.6.5
 - sassc 3.6.1 -> 3.6.2
 - gspell 1.8.3 -> 1.12.2
 - pandoc 2.13 -> 3.1.8
 - pypandoc 1.4 -> 1.11
 - regex 2020.2.20 -> 2023.8.8
 - pyenchant 3.0.1 -> 3.2.2
 - chardet 4.0.0 -> 5.2.0

It also:
- adds x-checker-data to all modules to keep them updated, with flathub.json to automerge PRs created by flathubbot (which will only be created on updates to apostrophe),
- splits python modules into a separate file generated by flatpak-pip-generator,
- removes pip and wheel as they don't seem to be needed(?).

The diff is horrendous, that is due to f-e-d-c using 4 space indents instead of 2 like the original file.