### PR TITLE
Require important update to trigger FEDC

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "require-important-update": true
+}

--- a/org.gnome.gitlab.somas.Apostrophe.json
+++ b/org.gnome.gitlab.somas.Apostrophe.json
@@ -174,7 +174,12 @@
                     "type": "git",
                     "url": "https://gitlab.gnome.org/World/apostrophe.git",
                     "tag": "v3.4",
-                    "commit": "c045f36e7e089134a0b2c62d85091037e5fcda4e"
+                    "commit": "c045f36e7e089134a0b2c62d85091037e5fcda4e",
+                    "x-checker-data": {
+                        "is-main-source": true,
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 }
             ],
             "post-install": [


### PR DESCRIPTION
> The tool will by default open PRs if at least one source is updated. Alternatively, the tool can be configured to only open PRs if at least one "important" source is updated. This can avoid unwanted PRs, e.g. PRs that only update a single library.

See: https://github.com/flathub-infra/flatpak-external-data-checker?tab=readme-ov-file#selectively-submitting-prs
